### PR TITLE
fix(webcams): hide previews that fail to decode (WebP on iOS webview)

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -237,6 +237,8 @@ export default function MapView() {
   const [zoom, setZoom] = useState<number>(13);
   const [webcams, setWebcams] = useState<WebcamItem[]>([]);
   const [activeWebcam, setActiveWebcam] = useState<WebcamItem | null>(null);
+  // Preview URLs that failed to decode (e.g. WebP the iOS webview can't render).
+  const [failedPreviews, setFailedPreviews] = useState<Set<string>>(new Set());
 
   // Start/End [lon, lat]
   const [startLonLat, setStartLonLat] = useState<[number, number] | null>(null);
@@ -1683,13 +1685,17 @@ export default function MapView() {
               <div style={{ fontSize: 12, fontWeight: 600, color: "#1e293b", marginBottom: 8 }}>
                 {activeWebcam.city || activeWebcam.region || activeWebcam.country || `${activeWebcam.lat.toFixed(5)}, ${activeWebcam.lon.toFixed(5)}`}
               </div>
-              {activeWebcam.preview && !isWebpPreviewUrl(activeWebcam.preview) ? (
+              {activeWebcam.preview && !isWebpPreviewUrl(activeWebcam.preview) && !failedPreviews.has(activeWebcam.preview) ? (
                 <Image
                   src={activeWebcam.preview}
                   alt={activeWebcam.title || "webcam preview"}
                   width={240}
                   height={120}
                   unoptimized
+                  onError={() => {
+                    const p = activeWebcam.preview;
+                    if (p) setFailedPreviews((prev) => new Set(prev).add(p));
+                  }}
                   style={{
                     width: "100%",
                     height: 120,

--- a/src/components/WebcamsPanel.tsx
+++ b/src/components/WebcamsPanel.tsx
@@ -35,6 +35,8 @@ export default function WebcamsPanel({
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [radiusKm, setRadiusKm] = useState(20);
+  // Previews that failed to decode (e.g. WebP the iOS webview can't render).
+  const [failedImgs, setFailedImgs] = useState<Set<string>>(new Set());
 
   const url = useMemo(() => {
     const p = new URLSearchParams({
@@ -105,10 +107,11 @@ export default function WebcamsPanel({
       <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 8, maxHeight: 280, overflow: "auto" }}>
         {items.map((w, idx) => {
           const img = imgOf(w);
-          const showImg = img && canShowImage(img);
+          const key = String(w.id ?? `${w.lat},${w.lon}`);
+          const showImg = img && canShowImage(img) && !failedImgs.has(key);
           const labelNum = idx + 1;
           return (
-            <div key={`${w.id ?? `${w.lat},${w.lon}`}`} style={{ display: "flex", gap: 8, borderBottom: "1px solid #f1f5f9", paddingBottom: 8 }}>
+            <div key={key} style={{ display: "flex", gap: 8, borderBottom: "1px solid #f1f5f9", paddingBottom: 8 }}>
               <div style={{ width: 96, height: 64, borderRadius: 6, overflow: "hidden", background: "#f1f5f9", flex: "0 0 auto", position: "relative" }}>
                 {showImg ? (
                   <Image
@@ -117,6 +120,7 @@ export default function WebcamsPanel({
                     width={96}
                     height={64}
                     unoptimized
+                    onError={() => setFailedImgs((prev) => new Set(prev).add(key))}
                     style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
                   />
                 ) : (


### PR DESCRIPTION
The URL-based webp filter only catches .webp/format=webp; WebP served from other URLs slips through and the iOS WKWebView throws a WebP decode error and shows a broken thumbnail. Add an onError handler on both the panel list and the map popup that hides any preview which fails to load (format-agnostic), falling back to the "no preview" placeholder.


## Test Steps
1. npm ci
2. npm run dev

## Check list
- [V] PR 標題含正確 Issue Key（如：SCRUM-17: …）
- [V] Commit 訊息含 Issue Key
- [V] Lint / Build / Typecheck 綠燈
- [V] 不含敏感資訊（API Key、密碼）
- [V] 文件/註解更新（如有）
