### PR TITLE
fix(ios): use @capacitor/geolocation so the location prompt appears

### DIFF
--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,16 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
+        .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@capacitor/cli": "^8.3.4",
         "@capacitor/core": "^8.3.4",
+        "@capacitor/geolocation": "^8.2.0",
         "@capacitor/ios": "^8.3.4",
         "@upstash/redis": "^1.35.4",
         "mapbox-gl": "^3.3.0",
@@ -71,6 +72,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.0.tgz",
+      "integrity": "sha512-N29QcoIPmme0xSxRkm7+3hjoHp6mBAOarxecvtCCZKyOBeKiJsFUq981cezg2XWBa6fhCXJMCCjQPngKK/dIag==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.4.tgz",
@@ -79,6 +92,12 @@
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@capacitor/cli": "^8.3.4",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/geolocation": "^8.2.0",
     "@capacitor/ios": "^8.3.4",
     "@upstash/redis": "^1.35.4",
     "mapbox-gl": "^3.3.0",

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -11,6 +11,7 @@ import WindLegend from "@/components/WindLegend";
 import ElevationPanel, { ElevPt } from "@/components/ElevationPanel";
 import MapboxRoutingPanel, { type Role as RoutingPanelRole } from "@/components/MapboxRoutingPanel";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Geolocation } from "@capacitor/geolocation";
 import type {
   LineLatLng,
   LonLat,
@@ -342,21 +343,35 @@ export default function MapView() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (!("geolocation" in navigator)) return;
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Best-effort: triggers the native iOS prompt; on web this resolves via
+        // the Permissions API. Wrapped so a web quirk can't block the read below.
+        try {
+          await Geolocation.requestPermissions();
+        } catch {
+          // ignore; getCurrentPosition still prompts/works
+        }
+        const pos = await Geolocation.getCurrentPosition({
+          enableHighAccuracy: false,
+          timeout: 20000,
+          maximumAge: 120000,
+        });
+        if (cancelled) return;
         const { latitude, longitude } = pos.coords;
         if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return;
         setMapCenter({ lat: latitude, lon: longitude });
         setZoom((z) => (z < 12 ? 12 : z));
         pendingGeoCenterRef.current = { lat: latitude, lon: longitude };
         tryFlyToPendingGeoCenter();
-      },
-      () => {
+      } catch {
         // Ignore location errors and keep default center.
-      },
-      { enableHighAccuracy: false, timeout: 20000, maximumAge: 120000 }
-    );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [tryFlyToPendingGeoCenter]);
 
   const loadCachedPresetRoute = (presetId: string): LonLat[] | null => {


### PR DESCRIPTION
## Revise Content
-WKWebView ignores web navigator.geolocation, so the iOS app never asked for location. Switch the map's geolocation effect to the Capacitor Geolocation plugin (native CoreLocation on iOS, navigator.geolocation on web), requesting permission then reading the position. Re-applies the fix on the #33 baseline.

## Test Steps
1. npm ci
2. npm run dev

## Check list
- [V] PR 標題含正確 Issue Key（如：SCRUM-17: …）
- [V] Commit 訊息含 Issue Key
- [V] Lint / Build / Typecheck 綠燈
- [V] 不含敏感資訊（API Key、密碼）
- [V] 文件/註解更新（如有）
