### PR TITLE
fix(splash): drop the in-webview splash, rely on the native launch sc…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,35 +1,12 @@
 "use client";
 import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
 
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false });
 
 export default function HomePage() {
-  const [showSplash, setShowSplash] = useState(true);
-
-  useEffect(() => {
-    const t = window.setTimeout(() => setShowSplash(false), 1000);
-    return () => window.clearTimeout(t);
-  }, []);
-
   return (
     <main style={{ height: "100dvh", width: "100%" }}>
-      {showSplash ? (
-        <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            backgroundColor: "#ffffff",
-            backgroundImage: 'url("/soonla-splash.jpg")',
-            backgroundRepeat: "no-repeat",
-            backgroundPosition: "center center",
-            backgroundSize: "contain",
-            zIndex: 9999,
-          }}
-        />
-      ) : (
-        <MapView />
-      )}
+      <MapView />
     </main>
   );
 }


### PR DESCRIPTION
## Revise Content
-The native launch (the .jpg logo, #39) already shows on open. The in-webview splash was loaded from the deployed site, so it showed stale cropped content and a second flash. Remove it and render the map directly — the native launch is the single splash now.

## Test Steps
1. npm ci
2. npm run dev

## Check list
- [V] PR 標題含正確 Issue Key（如：SCRUM-17: …）
- [V] Commit 訊息含 Issue Key
- [V] Lint / Build / Typecheck 綠燈
- [V] 不含敏感資訊（API Key、密碼）
- [V] 文件/註解更新（如有）
