### PR TITLE
perf(api): batch wind into one request, parallelize elevation

### DIFF
--- a/src/app/api/elevation/route.ts
+++ b/src/app/api/elevation/route.ts
@@ -205,29 +205,41 @@ export async function POST(req: NextRequest) {
       86400,
       async () => {
         const batchSize = 60;
-        const allPts: ElevPt[] = [];
+        const chunks: LonLat[][] = [];
         for (let i = 0; i < samples.length; i += batchSize) {
-          const chunk = samples.slice(i, i + batchSize);
+          chunks.push(samples.slice(i, i + batchSize));
+        }
+
+        const fetchChunk = async (chunk: LonLat[]): Promise<ElevPt[]> => {
           try {
-            const part = await fetchElevBatch(chunk, dataset, 20000);
-            allPts.push(...part);
+            return await fetchElevBatch(chunk, dataset, 20000);
           } catch {
             try {
-              const part = await fetchElevBatchFallback(chunk, 20000);
-              allPts.push(...part);
+              return await fetchElevBatchFallback(chunk, 20000);
             } catch {
               try {
-                const part = await fetchElevBatchMapbox(chunk, 20000);
-                allPts.push(...part);
+                return await fetchElevBatchMapbox(chunk, 20000);
               } catch {
-                for (const [lon, lat] of chunk) {
-                  allPts.push({ lat, lon, error: true, msg: "elev fetch failed" });
-                }
+                return chunk.map(([lon, lat]) => ({ lat, lon, error: true as const, msg: "elev fetch failed" }));
               }
             }
           }
-        }
-        return { points: allPts };
+        };
+
+        // Run chunks in parallel (bounded) instead of sequentially, preserving order.
+        const CONCURRENCY = 8;
+        const parts: ElevPt[][] = new Array(chunks.length);
+        let next = 0;
+        await Promise.all(
+          Array.from({ length: Math.max(1, Math.min(CONCURRENCY, chunks.length)) }, async () => {
+            while (true) {
+              const i = next++;
+              if (i >= chunks.length) return;
+              parts[i] = await fetchChunk(chunks[i]);
+            }
+          })
+        );
+        return { points: parts.flat() };
       },
       nocache,
       (payload) => payload.points.some((p) => typeof p.elevation === "number")

--- a/src/app/api/wind/route.ts
+++ b/src/app/api/wind/route.ts
@@ -10,6 +10,9 @@ type LatLon = [number, number]; // [lat, lon]
 // Upper bound on points per request to avoid fanning out into an unbounded
 // number of upstream Open-Meteo calls from a single public request.
 const MAX_POINTS = 2000;
+// Open-Meteo accepts many coordinates per request; chunk to stay well within
+// limits and keep each URL a sane length.
+const BATCH_SIZE = 100;
 
 function isValidLatLon(p: unknown): p is LatLon {
   return (
@@ -31,46 +34,25 @@ type WindPoint = {
   msg?: string;
 };
 
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  concurrency: number,
-  worker: (item: T, index: number) => Promise<R>
-): Promise<R[]> {
-  const out: R[] = new Array(items.length);
-  let next = 0;
+type OpenMeteoLoc = {
+  current?: { wind_speed_10m?: number; wind_direction_10m?: number };
+  hourly?: { time?: string[]; wind_speed_10m?: number[]; wind_direction_10m?: number[] };
+};
 
-  async function run() {
-    while (true) {
-      const idx = next++;
-      if (idx >= items.length) return;
-      out[idx] = await worker(items[idx], idx);
-    }
-  }
-
-  const n = Math.max(1, Math.min(concurrency, items.length));
-  await Promise.all(Array.from({ length: n }, () => run()));
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
   return out;
 }
 
-async function fetchWind(
-  lat: number,
-  lon: number,
-  forecastIsoUtc?: string,
-  timeoutMs = 12000
-) {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=wind_speed_10m,wind_direction_10m&hourly=wind_speed_10m,wind_direction_10m&wind_speed_unit=ms&timezone=UTC&forecast_days=16`;
-  const res = await fetch(url, { cache: "no-store", signal: AbortSignal.timeout(timeoutMs) });
-  if (!res.ok) throw new Error(`OpenMeteo ${res.status}`);
-  const j = (await res.json()) as {
-    current?: { wind_speed_10m?: number; wind_direction_10m?: number };
-    hourly?: { time?: string[]; wind_speed_10m?: number[]; wind_direction_10m?: number[] };
-  };
-  let sp = j.current?.wind_speed_10m ?? null; // m/s
-  let dir = j.current?.wind_direction_10m ?? null; // deg
-  if (forecastIsoUtc && j.hourly?.time?.length) {
-    const times = j.hourly.time;
-    const speeds = j.hourly.wind_speed_10m ?? [];
-    const dirs = j.hourly.wind_direction_10m ?? [];
+// Pick the current (or nearest-forecast) wind for one location's Open-Meteo result.
+function extractWind(loc: OpenMeteoLoc | undefined, forecastIsoUtc?: string) {
+  let sp = loc?.current?.wind_speed_10m ?? null; // m/s
+  let dir = loc?.current?.wind_direction_10m ?? null; // deg
+  if (forecastIsoUtc && loc?.hourly?.time?.length) {
+    const times = loc.hourly.time;
+    const speeds = loc.hourly.wind_speed_10m ?? [];
+    const dirs = loc.hourly.wind_direction_10m ?? [];
     const target = Date.parse(forecastIsoUtc);
     if (Number.isFinite(target)) {
       let bestIdx = -1;
@@ -100,6 +82,30 @@ async function fetchWind(
   };
 }
 
+// Fetch wind for many points in ONE Open-Meteo request (comma-separated coords),
+// instead of one request per point. Only request the (large) hourly forecast
+// when a forecast time is actually selected.
+async function fetchWindBatch(
+  batch: LatLon[],
+  forecastIsoUtc?: string,
+  timeoutMs = 20000
+): Promise<WindPoint[]> {
+  const lats = batch.map(([lat]) => lat).join(",");
+  const lons = batch.map(([, lon]) => lon).join(",");
+  const hourly = forecastIsoUtc
+    ? "&hourly=wind_speed_10m,wind_direction_10m&forecast_days=16"
+    : "";
+  const url =
+    `https://api.open-meteo.com/v1/forecast?latitude=${lats}&longitude=${lons}` +
+    `&current=wind_speed_10m,wind_direction_10m${hourly}&wind_speed_unit=ms&timezone=UTC`;
+  const res = await fetch(url, { cache: "no-store", signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) throw new Error(`OpenMeteo ${res.status}`);
+  const j = (await res.json()) as OpenMeteoLoc | OpenMeteoLoc[];
+  // Open-Meteo returns an array for multiple locations, a single object for one.
+  const arr = Array.isArray(j) ? j : [j];
+  return batch.map(([lat, lon], i) => ({ lat, lon, ...extractWind(arr[i], forecastIsoUtc) }));
+}
+
 export async function POST(req: NextRequest) {
   try {
     const { points, forecastIsoUtc } = (await req.json()) as { points?: LatLon[]; forecastIsoUtc?: string }; // [lat,lon]
@@ -119,27 +125,26 @@ export async function POST(req: NextRequest) {
     // 以「UTC 小時」做分桶，避免跨時段混用
     const now = forecastIsoUtc ? new Date(forecastIsoUtc) : new Date();
     const hourKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}-${now.getUTCHours()}`;
-    const key = buildKey("wind", { points, hourKey, unit: "ms", forecastIsoUtc: forecastIsoUtc ?? "", v: 3 });
+    const key = buildKey("wind", { points, hourKey, unit: "ms", forecastIsoUtc: forecastIsoUtc ?? "", v: 4 });
     const nocache = req.nextUrl.searchParams.get("nocache") === "1";
 
     const data = await cacheFetchJSON<{ points: WindPoint[] }>(
       key,
       90,
       async () => {
-        const out = await mapWithConcurrency(
-          points,
-          6,
-          async ([lat, lon]) => {
+        // One request per chunk; chunks run in parallel.
+        const batches = chunk(points, BATCH_SIZE);
+        const results = await Promise.all(
+          batches.map(async (b) => {
             try {
-              const w = await fetchWind(lat, lon, forecastIsoUtc, 12000);
-              return { lat, lon, ...w } satisfies WindPoint;
+              return await fetchWindBatch(b, forecastIsoUtc, 20000);
             } catch (e) {
               const msg = e instanceof Error ? e.message : "fetch failed";
-              return { lat, lon, error: true as const, msg } satisfies WindPoint;
+              return b.map(([lat, lon]) => ({ lat, lon, error: true as const, msg } satisfies WindPoint));
             }
-          }
+          })
         );
-        return { points: out };
+        return { points: results.flat() };
       },
       nocache
     );


### PR DESCRIPTION
## Revise Content

- /api/wind made one Open-Meteo call per point (16 points ≈ 14s). Batch all points into a single comma-separated request (chunked, parallel) and only pull the 16-day hourly payload when a forecast time is selected: 14.0s -> 2.0s for 16 points (~7x), and it scales to long routes.

- /api/elevation ran its provider batches sequentially. Run them in parallel (bounded to 8) preserving order: 3.9s -> 2.3s.

- Measured against the live providers; responses are identical in shape and fully populated.



## Test Steps
1. npm ci
2. npm run dev

## Check list
- [V] PR 標題含正確 Issue Key（如：SCRUM-17: …）
- [V] Commit 訊息含 Issue Key
- [V] Lint / Build / Typecheck 綠燈
- [V] 不含敏感資訊（API Key、密碼）
- [V] 文件/註解更新（如有）
