### PR TITLE
fix: stop infinite render loop in elevation panel

### DIFF
--- a/src/components/ElevationPanel.tsx
+++ b/src/components/ElevationPanel.tsx
@@ -31,18 +31,28 @@ export default function ElevationPanel({
     const el = containerRef.current;
     if (!el) return;
 
-    const update = () => {
-      const next = Math.max(220, Math.floor(el.clientWidth - 20));
-      setChartWidth(next);
-    };
-    update();
+    const apply = (w: number) => setChartWidth(Math.max(220, Math.floor(w)));
 
     if (typeof ResizeObserver !== "undefined") {
-      const ro = new ResizeObserver(() => update());
+      // Size the chart to the panel's content box (padding excluded). Guessing
+      // the padding (e.g. clientWidth - 20) can leave the SVG a few px too wide;
+      // it then overflows and grows the panel, which re-fires the observer in an
+      // infinite loop ("Maximum update depth exceeded"). contentRect is exact,
+      // so the SVG always fits and the width settles.
+      const ro = new ResizeObserver((entries) => {
+        const cr = entries[0]?.contentRect;
+        if (cr && cr.width > 0) apply(cr.width);
+      });
       ro.observe(el);
       return () => ro.disconnect();
     }
 
+    const update = () => {
+      const cs = getComputedStyle(el);
+      const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+      apply(el.clientWidth - padX);
+    };
+    update();
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
   }, []);


### PR DESCRIPTION
## Revise Content
The restyle bumped the panel's compact padding 10->12, but the ResizeObserver still sized the chart with `clientWidth - 20` (which only matched 10px padding). With 12px padding the SVG came out ~4px too wide, overflowed the content-sized panel, grew it, and re-fired the observer — an unbounded feedback loop that surfaced as "Maximum update depth exceeded" at setHoverX.

Size the chart to the observer's contentRect.width (padding excluded) instead, so the SVG always fits exactly and the width settles. Fallback path (no ResizeObserver) reads real computed padding rather than a guess.

## Test Steps
1. npm ci
2. npm run dev

## Check list
- [V] PR 標題含正確 Issue Key（如：SCRUM-17: …）
- [V] Commit 訊息含 Issue Key
- [V] Lint / Build / Typecheck 綠燈
- [V] 不含敏感資訊（API Key、密碼）
- [V] 文件/註解更新（如有）
