### PR TITLE
chore(ios): register splash-screen plugin in SPM package

### DIFF
--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
-        .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation")
+        .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation"),
+        .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen")
     ],
     targets: [
         .target(
@@ -20,7 +21,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation")
+                .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation"),
+                .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen")
             ]
         )
     ]


### PR DESCRIPTION
`cap sync` added `@capacitor/splash-screen` to the SwiftPM manifest (`ios/App/CapApp-SPM/Package.swift`). Commit it so the iOS project builds the plugin it already depends on.

Verified: `npm run ios:bundle` + `xcodebuild` → BUILD SUCCEEDED, installed and launched on iPhone 17 Pro (onboarding + restyle render, location deferred correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)