### PR TITLE
chore(ios): version 1.1.1 (build 2) + deep-link params

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -309,14 +309,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = soonla.tailwindsprint.com;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -331,14 +331,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = soonla.tailwindsprint.com;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,9 +12,17 @@ export default function HomePage() {
   // Whether we've checked localStorage yet — gates the location request so it
   // never fires before we know if onboarding should show.
   const [onboardingDecided, setOnboardingDecided] = useState(false);
+  // Suppress the location request entirely (e.g. ?nolocate=1 for screenshots).
+  const [noLocate, setNoLocate] = useState(false);
 
   useEffect(() => {
     try {
+      // Allow deep links to skip onboarding (e.g. ?onboarded=1), useful for
+      // shared route links and screenshots.
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("nolocate") === "1") setNoLocate(true);
+      const skip = params.get("onboarded") === "1";
+      if (skip) window.localStorage.setItem(ONBOARDED_KEY, "1");
       if (!window.localStorage.getItem(ONBOARDED_KEY)) setShowOnboarding(true);
     } catch {
       // localStorage unavailable — skip onboarding rather than block the app.
@@ -34,7 +42,7 @@ export default function HomePage() {
   return (
     <main style={{ height: "100dvh", width: "100%" }}>
       {/* Ask for location only after the welcome is dismissed (or skipped). */}
-      <MapView locationEnabled={onboardingDecided && !showOnboarding} />
+      <MapView locationEnabled={onboardingDecided && !showOnboarding && !noLocate} />
       {showOnboarding && <Onboarding onDismiss={dismissOnboarding} />}
     </main>
   );


### PR DESCRIPTION
Sets MARKETING_VERSION to 1.1.1 and CURRENT_PROJECT_VERSION to 2 (build numbers must increase per upload), and adds harmless deep-link params `?onboarded=1` / `?nolocate=1` (skip onboarding / suppress auto-location) useful for shared links, testing, and screenshots. Verified the build resolves to 1.1.1 (build 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)