### PR TITLE
docs: App Store prep (privacy policy, listing, submission runbook)

### DIFF
--- a/docs/app-store-listing.md
+++ b/docs/app-store-listing.md
@@ -1,0 +1,100 @@
+# Soonla — App Store Connect listing
+
+Copy/paste reference for the App Store submission. Edit the wording to taste.
+
+## Basics
+
+- **App name:** Soonla
+- **Subtitle (≤30 chars):** `Wind-smart cycling routes`
+- **Bundle ID:** `soonla.tailwindsprint.com`
+- **Primary category:** Navigation _(alt: Sports / Health & Fitness)_
+- **Secondary category (optional):** Sports
+- **Version:** 1.1.1
+- **Age rating:** 4+ (no objectionable content)
+- **Price:** Free
+
+## Promotional text (≤170 chars, editable anytime without review)
+
+```
+Plan smarter rides. See tailwind vs. headwind along your whole route, check
+every climb, and peek at nearby webcams before you roll out.
+```
+
+## Description
+
+```
+Soonla helps you plan cycling routes with the wind and the hills in mind.
+
+Most route planners stop at "fastest" or "shortest." Soonla shows you what the
+ride will actually feel like — where you'll have a tailwind pushing you along,
+and where you'll be grinding into a headwind.
+
+PLAN A ROUTE
+Search or tap the map to set your start, end, and stops — or pick a preset and
+go. Soonla draws a cycling-friendly route in seconds.
+
+READ THE WIND
+Your route is colored from tailwind to headwind using live wind data, so you can
+choose the smarter direction and pace yourself for the tough stretches.
+
+CHECK THE CLIMB
+A clear elevation profile shows every slope along the way, with a rider that
+tilts to match the gradient — so there are no surprises on the road.
+
+NEARBY WEBCAMS
+Peek at live webcams near your route to check real conditions before you head
+out.
+
+Soonla has no accounts, no ads, and no tracking. Just plan and ride.
+```
+
+## Keywords (≤100 chars, comma-separated, no spaces after commas)
+
+```
+cycling,bike,route,wind,headwind,tailwind,elevation,climb,gradient,ride,planner,gps,road,weather
+```
+
+## URLs
+
+- **Support URL:** _(required)_ — e.g. a simple page or the GitHub repo:
+  `https://github.com/YuMei13/tailwind-sprint`
+- **Marketing URL (optional):** your site, if any
+- **Privacy Policy URL:** _(required — you must host this)_
+  host `docs/privacy-policy.md` somewhere public and put the URL here.
+  Easiest options: GitHub Pages, or add a `/privacy` page to your web app.
+
+## App Privacy ("nutrition label") answers
+
+In App Store Connect → App Privacy, answer the questionnaire as follows. This
+matches what the app actually does (no analytics, no accounts, no tracking).
+
+**Do you or your third-party partners collect data from this app?**
+→ The honest answer is **Yes** — because "Location" is sent to service providers
+to deliver features. Declare it minimally:
+
+| Data type | Collected? | Linked to identity? | Used for tracking? | Purpose |
+|---|---|---|---|---|
+| **Precise Location** | Yes | **No** | **No** | App Functionality (routing, wind, nearby webcams) |
+| Everything else (name, email, contacts, identifiers, usage, diagnostics, purchases, etc.) | **No** | — | — | — |
+
+Key follow-up answers:
+- **Used to track you?** → **No** (no advertising/cross-app tracking).
+- **Linked to your identity?** → **No** (no accounts; location isn't tied to a user).
+- Location purpose → **App Functionality** only (not analytics, not ads).
+
+> Note: the on-device storage (onboarding flag, route presets) is **not**
+> "collected" in Apple's sense because it never leaves the device — you don't
+> declare it.
+
+## Review notes (App Review → Notes field)
+
+```
+Soonla is a cycling route planner. It uses location to center the map and to
+plan routes / fetch wind and nearby webcams from public mapping and weather APIs
+(Mapbox, OpenRouteService, Open-Meteo, OpenTopoData, Windy). There are no
+accounts — no login is required to review the app. Just allow location (or deny
+it and tap the map to set points) and plan a route.
+```
+
+## "Sign in required?" → No
+No demo account needed; reviewers can use all features without logging in.

--- a/docs/app-store-submission.md
+++ b/docs/app-store-submission.md
@@ -1,0 +1,159 @@
+# Shipping Soonla to the App Store — runbook
+
+The technical prep is done (icon, version 1.1.1 / build 2, privacy policy,
+listing text). What remains are the steps **only you can do** — they need your
+Apple ID, your money, and your API keys. Follow these in order.
+
+Bundle ID: **`soonla.tailwindsprint.com`** · Version: **1.1.1 (build 2)**
+
+---
+
+## Phase 1 — Enroll in the Apple Developer Program (~$99/yr, 24–48h)
+
+1. Go to https://developer.apple.com/programs/ → **Enroll**.
+2. Sign in with your Apple ID (turn on two-factor auth if prompted).
+3. Choose **Individual** (recommended — fastest, no D-U-N-S number needed; your
+   legal name shows as the seller). Pick **Organization** only if you have a
+   registered company and want the company name shown.
+4. Pay the **$99** annual fee. Apple may ask you to verify your identity in the
+   **Apple Developer** app on your iPhone.
+5. Wait for the approval email (usually a day or two).
+
+You can't do any of the later phases until this clears.
+
+---
+
+## Phase 2 — Deploy your own backend (so the app doesn't depend on the frozen Vercel)
+
+The app calls `/api/*` for routing, geocoding, wind, elevation, and webcams.
+Routing/geocode/webcams need **secret API keys**, so they must live on a server
+— they can't be embedded in the app. Redeploy the same code to a **new Vercel
+project under your own account**.
+
+1. Push the repo to GitHub (already done: `YuMei13/tailwind-sprint`).
+2. Go to https://vercel.com → log in with **your** account → **Add New →
+   Project** → import `tailwind-sprint`.
+3. Framework preset: **Next.js**. Leave build settings default. **Do not** set
+   `CAPACITOR_BUILD` (you want the full server build with `/api`, not the static
+   export).
+4. Add **Environment Variables** (Production). Copy the values from your local
+   `.env.local`:
+   - `ORS_API_KEY`
+   - `MAPBOX_ACCESS_TOKEN`
+   - `NEXT_PUBLIC_MAPBOX_TOKEN`
+   - `WINDY_WEBCAMS_KEY`
+   - `UPSTASH_REDIS_REST_URL`
+   - `UPSTASH_REDIS_REST_TOKEN`
+   - `PUBLIC_SITE_URL` → set to your new Vercel URL (e.g. `https://soonla.vercel.app`)
+5. **Deploy.** Note the production URL (e.g. `https://soonla-xxxx.vercel.app`).
+6. Test it: open `https://YOUR-URL/api/wind` etc. should respond (not 404/500).
+
+> Cost: this traffic almost certainly fits Vercel's free tier. Keep the project
+> alive — if it goes down, installed apps lose their data.
+
+---
+
+## Phase 3 — Rebuild the app bundle pointed at your backend
+
+On your Mac, in the repo:
+
+```bash
+NEXT_PUBLIC_API_BASE="https://YOUR-NEW-VERCEL-URL" npm run ios:bundle
+```
+
+This builds the static front-end, points it at your backend, and runs
+`cap sync ios`. Then open Xcode:
+
+```bash
+open ios/App/App.xcworkspace
+```
+
+(If there's no `.xcworkspace`, open `ios/App/App.xcodeproj`.)
+
+---
+
+## Phase 4 — Screenshots (do these once the app is running on your Mac)
+
+App Store Connect requires screenshots for a **6.9-inch iPhone** (iPhone 16/17
+Pro Max). Easiest path:
+
+1. In Xcode, run the app on an **iPhone 17 Pro Max** simulator.
+2. Tap **Allow While Using App** on the location prompt (the one I couldn't tap
+   from here).
+3. Plan a route (search a start/end, or tap the map). Wait for the wind-colored
+   route + elevation panel.
+4. Capture with **⌘S** in the simulator (saves to Desktop), for 3–5 screens:
+   - the welcome/onboarding screen,
+   - a planned route with the wind coloring,
+   - the elevation profile,
+   - the nearby-webcams panel.
+
+Tip: you can deep-link straight to a planned route with the params
+`?start=LAT,LON&end=LAT,LON&onboarded=1` if you run the web app, or just plan
+in-app.
+
+---
+
+## Phase 5 — Create the app in App Store Connect
+
+1. Go to https://appstoreconnect.apple.com → **My Apps → +  → New App**.
+2. Platform **iOS**, name **Soonla**, primary language, bundle ID
+   **`soonla.tailwindsprint.com`** (it appears in the dropdown once your
+   developer account is active and the ID is registered — Xcode registers it on
+   first archive, or add it under Certificates, IDs & Profiles → Identifiers).
+3. Fill in the listing using **`docs/app-store-listing.md`**: subtitle,
+   description, keywords, promotional text, support URL, **privacy policy URL**
+   (host `docs/privacy-policy.md` first — see below), category, age rating.
+4. Complete **App Privacy** using the table in the listing doc (Precise
+   Location → App Functionality, not linked to identity, not used for tracking;
+   everything else No).
+5. Upload the screenshots from Phase 4.
+
+### Hosting the privacy policy
+You need a public URL. Quickest options:
+- **GitHub Pages:** enable Pages on the repo, the markdown renders at a public
+  URL, paste that.
+- **Or** add a `/privacy` route to your web app that renders the policy, and use
+  `https://YOUR-VERCEL-URL/privacy`.
+
+---
+
+## Phase 6 — Sign, archive, upload
+
+In Xcode:
+
+1. Select the **App** target → **Signing & Capabilities**.
+2. Check **Automatically manage signing**, choose your **Team** (your developer
+   account). Xcode creates the distribution certificate + provisioning profile.
+3. Set the run destination to **Any iOS Device (arm64)** (not a simulator).
+4. **Product → Archive.** When it finishes, the Organizer opens.
+5. **Distribute App → App Store Connect → Upload.** Accept the defaults; let
+   Xcode handle signing.
+6. Wait ~15–30 min for the build to finish processing in App Store Connect.
+
+---
+
+## Phase 7 — Submit for review
+
+1. In App Store Connect, open the app → your **1.1.1** version.
+2. Under **Build**, select the uploaded build (build 2).
+3. Add the **review notes** from the listing doc, confirm **no sign-in
+   required**, set export-compliance (this app uses only standard HTTPS →
+   typically "No" to custom encryption / exempt).
+4. **Add for Review → Submit.**
+
+First review is usually **1–3 days**. If rejected, Apple tells you why in
+Resolution Center — common ones for wrapper apps are Guideline 4.2 (minimum
+functionality) and privacy-string clarity; both are addressed here (native
+location, real features, clear usage string).
+
+---
+
+## Quick reference — what's already done
+
+- ✅ App icon (Didot "S" monogram), opaque 1024×1024, in the AppIcon set
+- ✅ Version **1.1.1**, build **2** (in the Xcode project)
+- ✅ Self-contained bundle architecture (`npm run ios:bundle`)
+- ✅ Privacy policy draft → `docs/privacy-policy.md`
+- ✅ Listing text + App Privacy answers → `docs/app-store-listing.md`
+- ⬜ Everything in Phases 1–7 above (needs your account / keys / device)

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,82 @@
+# Soonla — Privacy Policy
+
+_Last updated: 14 June 2026_
+
+Soonla ("the app") helps you plan cycling routes with wind and elevation in
+mind. This policy explains what data the app uses, why, and who it is shared
+with. We aim to collect as little as possible.
+
+## Summary
+
+- We **do not** have user accounts, and we **do not** track you across apps or
+  websites.
+- We **do not** use any advertising or analytics SDKs.
+- The app uses your **location** only to show your position on the map and to
+  plan routes and fetch nearby conditions you ask for.
+- Route planning, wind, elevation, and webcam features work by sending the
+  relevant coordinates to mapping and weather providers to get results back.
+
+## Information the app uses
+
+### Location
+With your permission, the app accesses your device location to:
+- center the map on where you are, and
+- use your position as a starting point for routes, wind, and nearby webcam
+  lookups.
+
+Your location is used on-device and is included in requests to the mapping and
+weather services listed below **only when needed to fulfil a feature you
+trigger** (for example, planning a route from your location). We do not keep a
+history of your location on our servers, and we do not use it to identify you.
+
+You can deny or revoke location access at any time in **Settings → Privacy &
+Security → Location Services**. The app still works; it just won't auto-center
+on you.
+
+### Route and map coordinates
+When you plan a route, search for a place, view the wind along a path, read an
+elevation profile, or look for nearby webcams, the app sends the relevant
+coordinates (such as start, end, and waypoints) to the service providers below
+to return results. These coordinates are not linked to your identity.
+
+### On-device storage
+The app stores a small amount of data **on your device only** (using local
+storage), such as whether you've seen the welcome screen and recently used route
+presets. This never leaves your device and is removed if you delete the app.
+
+## Third-party services
+
+To provide its features, the app sends requests to the following providers.
+Each has its own privacy policy governing how they handle request data:
+
+- **Mapbox** — maps, geocoding (search), and routing. https://www.mapbox.com/legal/privacy
+- **OpenRouteService** — routing and geocoding. https://openrouteservice.org/privacy-policy/
+- **Open-Meteo** — wind and weather data. https://open-meteo.com/en/terms
+- **OpenTopoData** — elevation data. https://www.opentopodata.org/
+- **Windy.com Webcams** — nearby live webcams. https://www.windy.com/privacy-policy
+- **Soonla backend** — a service operated by us that relays the requests above
+  and caches results to keep the app fast. It does not store your personal data
+  or build a profile of you.
+
+We do not sell your data, and we do not share it with anyone other than the
+providers needed to deliver the feature you used.
+
+## Data we do **not** collect
+
+- No name, email, phone number, or account.
+- No advertising identifiers; no cross-app or cross-site tracking.
+- No analytics or crash-tracking SDKs.
+
+## Children
+
+Soonla is not directed at children and does not knowingly collect personal
+information from children.
+
+## Changes
+
+If this policy changes, we will update the "Last updated" date above and post
+the new version at the same URL.
+
+## Contact
+
+Questions about this policy? Contact us at: **yenchung207@gmail.com**


### PR DESCRIPTION
App Store submission prep docs:
- `docs/privacy-policy.md` — privacy policy (location for app functionality only; no accounts/analytics/ads/tracking)
- `docs/app-store-listing.md` — description, keywords, App Privacy answers, review notes
- `docs/app-store-submission.md` — step-by-step runbook for enroll → deploy backend → screenshots → sign → submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)